### PR TITLE
Add support for custom headers in SFTPGo provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# Binary
 terraform-provider-sftpgo*
+
+# OS generated files
+.DS_Store
+
+# JetBrains IDEs files
+.idea/
+*.iws

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+.PHONY: dependencies generate build install test testacc docs
+
 default: install
+
+dependencies:
+	go install github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 generate:
 	go generate ./...
@@ -14,3 +19,6 @@ test:
 
 testacc:
 	TF_ACC=1 go test -v -count=1 -parallel=4 -timeout 10m -v ./...
+
+docs:
+	tfplugindocs generate --provider-name sftpgo

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,15 @@ provider "sftpgo" {
 ### Optional
 
 - `api_key` (String, Sensitive) SFTPGo API key. May also be provided via SFTPGO_API_KEY environment variable. You must provide an API key or username and password. If both an API key and username and password are provided, the API key will be used.
+- `headers` (Attributes List) Headers to include in requests to the SFTPGo API. Each header is represented as a map with `name` and `value` keys. (see [below for nested schema](#nestedatt--headers))
 - `host` (String) URI for SFTPGo API. May also be provided via SFTPGO_HOST environment variable.
 - `password` (String, Sensitive) Password for SFTPGo API. May also be provided via SFTPGO_PASSWORD environment variable.
 - `username` (String) Username for SFTPGo API. May also be provided via SFTPGO_USERNAME environment variable.
+
+<a id="nestedatt--headers"></a>
+### Nested Schema for `headers`
+
+Optional:
+
+- `name` (String) The header name
+- `value` (String) The header value

--- a/examples/iap/main.tf
+++ b/examples/iap/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    sftpgo = {
+      source = "registry.terraform.io/drakkan/sftpgo"
+    }
+  }
+}
+
+data "google_service_account_id_token" "sftp_iap_oidc" {
+  target_service_account = var.sftp_service_account
+  target_audience        = var.sftp_iap_client_id
+  include_email          = true
+}
+
+provider "sftpgo" {
+  host     = "http://localhost:8080"
+  username = "admin"
+  password = "password"
+
+  headers = [
+    {
+      name  = "Proxy-Authorization"
+      value = "Bearer ${data.google_service_account_id_token.sftp_iap_oidc.id_token}"
+    }
+  ]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drakkan/terraform-provider-sftpgo
 
-go 1.22
+go 1.21
 
 require (
 	github.com/hashicorp/terraform-plugin-docs v0.18.0

--- a/sftpgo/client/client.go
+++ b/sftpgo/client/client.go
@@ -33,6 +33,7 @@ type Client struct {
 	AccessToken string
 	APIKey      string
 	Auth        AuthStruct
+	Headers     map[string]string
 }
 
 // AuthStruct defines th SFTPGo API auth
@@ -57,7 +58,7 @@ type backupData struct {
 }
 
 // NewClient return an SFTPGo API client
-func NewClient(host, username, password, apiKey *string) (*Client, error) {
+func NewClient(host, username, password, apiKey *string, headers map[string]string) (*Client, error) {
 	c := Client{
 		HTTPClient: &http.Client{Timeout: 10 * time.Second},
 		// Default SFTPGo URL
@@ -83,6 +84,8 @@ func NewClient(host, username, password, apiKey *string) (*Client, error) {
 		Password: *password,
 	}
 
+	c.Headers = headers
+
 	ar, err := c.SignInAdmin()
 	if err != nil {
 		return nil, err
@@ -99,6 +102,13 @@ func (c *Client) doRequest(req *http.Request, expectedStatusCode int) ([]byte, e
 	} else if c.APIKey != "" {
 		req.Header.Set("X-SFTPGO-API-KEY", c.APIKey)
 	}
+
+	if c.Headers != nil {
+		for k, v := range c.Headers {
+			req.Header.Set(k, v)
+		}
+	}
+
 	if req.Body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/sftpgo/provider_test.go
+++ b/sftpgo/provider_test.go
@@ -28,5 +28,9 @@ func getClient() (*client.Client, error) {
 	host := os.Getenv("SFTPGO_HOST")
 	user := os.Getenv("SFTPGO_USERNAME")
 	pwd := os.Getenv("SFTPGO_PASSWORD")
-	return client.NewClient(&host, &user, &pwd, nil)
+
+	headers := map[string]string{
+		"FOO": "BAR",
+	}
+	return client.NewClient(&host, &user, &pwd, nil, headers)
 }


### PR DESCRIPTION
This pull request adds support for custom headers in the SFTPGo Terraform provider, facilitating the inclusion of additional headers in requests to the SFTPGo API. This feature is particularly useful for scenarios like bypassing IAP on Google Cloud Platform by allowing additional headers like "Proxy-Authorization".

**Changes:**
- Added a new optional field `headers` in the provider configuration schema, enabling users to specify custom headers as key-value pairs.
- Integrated the `headers` field into the provider implementation, allowing these headers to be included in requests to the SFTPGo API.
- Provided an example usage of the `headers` field in `examples/iap/main.tf`, demonstrating how to pass custom headers such as "Proxy-Authorization" to bypass IAP.
- Reverted go version back to `1.21` since `1.22` is missing toolchain for darwin/arm64 based machines


Please review and merge at your earliest convenience.