### PR TITLE
fix: provider events condition rule

### DIFF
--- a/sftpgo/models.go
+++ b/sftpgo/models.go
@@ -2593,7 +2593,7 @@ func (c *ruleConditions) toSFTPGo(ctx context.Context) (client.EventRuleConditio
 		}
 	}
 	if !c.ProviderEvents.IsNull() {
-		diags := c.FsEvents.ElementsAs(ctx, &conditions.ProviderEvents, false)
+		diags := c.ProviderEvents.ElementsAs(ctx, &conditions.ProviderEvents, false)
 		if diags.HasError() {
 			return conditions, diags
 		}


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---

The provider event rule doesn't work.  Test it with:

```tf
resource "sftpgo_rule" "mkdir" {
     name = "Create directory on user creation"
      status = 1
      trigger = 2
      conditions = {
        provider_events = ["add"]
        options = {
          provider_objects = ["user"]
        }
      }
      actions = [ {
        name = "<name of the action>"
      } ]
}
```