### PR TITLE
fix(resource): handle resource removed outside terraform (404)

### DIFF
--- a/sftpgo/action_resource.go
+++ b/sftpgo/action_resource.go
@@ -596,6 +596,12 @@ func (r *actionResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	action, err := r.client.GetAction(state.Name.ValueString())
 	if err != nil {
+		// Check if the action was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Event Action",
 			"Could not read SFTPGo Event Action "+state.Name.ValueString()+": "+err.Error(),

--- a/sftpgo/admin_resource.go
+++ b/sftpgo/admin_resource.go
@@ -255,6 +255,12 @@ func (r *adminResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	admin, err := r.client.GetAdmin(state.Username.ValueString())
 	if err != nil {
+		// Check if the admin was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Admin",
 			"Could not read SFTPGo Admin "+state.Username.ValueString()+": "+err.Error(),

--- a/sftpgo/allowlist_entry_resource.go
+++ b/sftpgo/allowlist_entry_resource.go
@@ -148,6 +148,12 @@ func (r *allowListEntryResource) Read(ctx context.Context, req resource.ReadRequ
 
 	entry, err := r.client.GetIPListEntry(1, state.IPOrNet.ValueString())
 	if err != nil {
+		// Check if the entry was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo allow list entry",
 			"Could not read SFTPGo allow list entry "+state.IPOrNet.ValueString()+": "+err.Error(),

--- a/sftpgo/client/client.go
+++ b/sftpgo/client/client.go
@@ -22,6 +22,16 @@ import (
 	"time"
 )
 
+// StatusError represents an HTTP error with status code
+type StatusError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e StatusError) Error() string {
+	return fmt.Sprintf("status: %d, body: %s", e.StatusCode, e.Body)
+}
+
 // HostURL - Default SFTPGo URL
 const HostURL string = "http://localhost:8080"
 
@@ -166,7 +176,10 @@ func (c *Client) doRequest(req *http.Request, expectedStatusCode int) ([]byte, e
 	}
 
 	if res.StatusCode != expectedStatusCode {
-		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, body)
+		return nil, StatusError{
+			StatusCode: res.StatusCode,
+			Body:       body,
+		}
 	}
 
 	return body, err

--- a/sftpgo/defender_entry_resource.go
+++ b/sftpgo/defender_entry_resource.go
@@ -157,6 +157,12 @@ func (r *defenderEntryResource) Read(ctx context.Context, req resource.ReadReque
 
 	entry, err := r.client.GetIPListEntry(2, state.IPOrNet.ValueString())
 	if err != nil {
+		// Check if the entry was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo defender entry",
 			"Could not read SFTPGo defender entry "+state.IPOrNet.ValueString()+": "+err.Error(),

--- a/sftpgo/folder_resource.go
+++ b/sftpgo/folder_resource.go
@@ -156,6 +156,12 @@ func (r *folderResource) Read(ctx context.Context, req resource.ReadRequest, res
 
 	folder, err := r.client.GetFolder(state.Name.ValueString())
 	if err != nil {
+		// Check if the folder was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Folder",
 			"Could not read SFTPGo Folder "+state.Name.ValueString()+": "+err.Error(),

--- a/sftpgo/group_resource.go
+++ b/sftpgo/group_resource.go
@@ -207,6 +207,12 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	group, err := r.client.GetGroup(state.Name.ValueString())
 	if err != nil {
+		// Check if the group was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Group",
 			"Could not read SFTPGo Group "+state.Name.ValueString()+": "+err.Error(),

--- a/sftpgo/rlsafelist_entry_resource.go
+++ b/sftpgo/rlsafelist_entry_resource.go
@@ -148,6 +148,12 @@ func (r *rlSafeListEntryResource) Read(ctx context.Context, req resource.ReadReq
 
 	entry, err := r.client.GetIPListEntry(3, state.IPOrNet.ValueString())
 	if err != nil {
+		// Check if the entry was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo rate limiters safe list entry",
 			"Could not read SFTPGo rate limiters safe list entry "+state.IPOrNet.ValueString()+": "+err.Error(),

--- a/sftpgo/role_resource.go
+++ b/sftpgo/role_resource.go
@@ -144,6 +144,12 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	role, err := r.client.GetRole(state.Name.ValueString())
 	if err != nil {
+		// Check if the role was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Role",
 			"Could not read SFTPGo Role "+state.Name.ValueString()+": "+err.Error(),

--- a/sftpgo/rule_resource.go
+++ b/sftpgo/rule_resource.go
@@ -349,6 +349,12 @@ func (r *ruleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	rule, err := r.client.GetRule(state.Name.ValueString())
 	if err != nil {
+		// Check if the rule was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo Event Rule",
 			"Could not read SFTPGo Event Rule "+state.Name.ValueString()+": "+err.Error(),

--- a/sftpgo/user_resource.go
+++ b/sftpgo/user_resource.go
@@ -293,6 +293,12 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	user, err := r.client.GetUser(state.Username.ValueString())
 	if err != nil {
+		// Check if the user was not found (404 error)
+		if statusErr, ok := err.(client.StatusError); ok && statusErr.StatusCode == 404 {
+			// Resource has been deleted outside of Terraform, remove it from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Reading SFTPGo User",
 			"Could not read SFTPGo User "+state.Username.ValueString()+": "+err.Error(),


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
# Description
This pull request improves how resource "read" operations handle cases where resources have been deleted outside of Terraform. Now, if a resource is not found (returns a 404 error), it is automatically removed from Terraform state instead of causing an error. This change makes the provider more robust and user-friendly when resources are deleted externally.

## Error Handling Improvements

* Introduced a new `StatusError` type in `sftpgo/client/client.go` to represent HTTP errors with status codes, allowing for more granular error handling.
* Updated the `doRequest` method in `sftpgo/client/client.go` to return a `StatusError` when an unexpected status code is received, instead of a generic error.


# Example :
1. Before adding terraform user : 
<img width="719" height="396" alt="{BE53C6CD-CBF8-42F7-B9C2-FD00BADBF16B}" src="https://github.com/user-attachments/assets/d09aa531-74d0-4f50-a31f-5d9c304ebcfa" />
2. Create user with terraform : 
<img width="708" height="367" alt="{318CD3D7-3DD9-43C8-ACE6-E7743D0FFE6F}" src="https://github.com/user-attachments/assets/1e004512-8496-47a6-8a77-d70406d5e1d9" />
<img width="726" height="400" alt="{FF8DE395-2ED9-40E6-902B-42050FE18AEF}" src="https://github.com/user-attachments/assets/13b4eb6c-7d62-4b6b-8df6-93777f7eafc0" />

3. Remove this user manually from interface : 
<img width="691" height="272" alt="{65012D78-DD3C-412F-AA81-8591D8DA3180}" src="https://github.com/user-attachments/assets/e09232ef-f6b9-4dba-82cc-eb57ba4a300c" />

4. Run terraform : 
a. Before this pull request : 
<img width="959" height="268" alt="{ED95C829-A131-4F0D-A2A1-BF64BEF0314D}" src="https://github.com/user-attachments/assets/ac63a29b-f388-4505-ac85-bfd2448b5941" />

b. After this pull request :
<img width="738" height="366" alt="{216B52FF-5879-4BE9-8F7C-99A736BE1C9F}" src="https://github.com/user-attachments/assets/ed9c3fc5-6a4a-4000-9986-de3d637f7da8" />


With this change, Terraform can truly remain the single source of truth for the resources it manages, even when external deletions occur.

