### PR TITLE
Fix inconsistent sensitive attribute for Azure Blob Storage

### DIFF
--- a/sftpgo/util.go
+++ b/sftpgo/util.go
@@ -185,10 +185,12 @@ func getComputedSchemaForFilesystem() schema.SingleNestedAttribute {
 					},
 					"account_key": schema.StringAttribute{
 						Computed:    true,
+						Sensitive:   true,
 						Description: computedSecretDescription,
 					},
 					"sas_url": schema.StringAttribute{
 						Computed:    true,
+						Sensitive:   true,
 						Description: computedSecretDescription,
 					},
 					"endpoint": schema.StringAttribute{


### PR DESCRIPTION
# Checklist for Pull Requests

- [x] Have you signed the [Contributor License Agreement](https://sftpgo.com/cla.html)?

---
# Fix: Inconsistent sensitive attribute for Azure Blob Storage filesystem config

## Problem

When using Azure Blob Storage filesystem configuration (provider = 3), resources were incorrectly marked as tainted after every successful `terraform apply`, causing the following error:

```
Error: Provider produced inconsistent result after apply

When applying changes to [resource], provider "registry.terraform.io/drakkan/sftpgo"
produced an unexpected new value: .filesystem: inconsistent values for sensitive attribute.
```

**Impact:**
- Resources marked as tainted after every successful apply
- Subsequent `terraform plan` would show resource needs to be destroyed and recreated
- Required manual `terraform untaint` after every apply
- Prevented reliable infrastructure automation

**Affected resources:**
- `sftpgo_user` with Azure Blob Storage filesystem
- `sftpgo_folder` with Azure Blob Storage filesystem
- `sftpgo_group` with Azure Blob Storage filesystem

## Root Cause

The provider defined inconsistent sensitivity markers between input and computed schemas for `azblobconfig`:

**Input schema** (lines 511-519):
- `account_key` marked with `Sensitive: true` ✓
- `sas_url` marked with `Sensitive: true` ✓

**Computed schema** (lines 186-194):
- `account_key` missing `Sensitive: true` ✗
- `sas_url` missing `Sensitive: true` ✗

When Terraform compared the planned state (with sensitivity metadata) against the applied state (without sensitivity metadata), it detected an inconsistency and marked resources as tainted.

## Solution

Added `Sensitive: true` markers to `account_key` and `sas_url` fields in the computed schema (`getComputedSchemaForFilesystem()`) to match the input schema definition.

**Changes:**

```diff
diff --git a/sftpgo/util.go b/sftpgo/util.go
index 4fc7115..0099eef 100644
--- a/sftpgo/util.go
+++ b/sftpgo/util.go
@@ -185,10 +185,12 @@ func getComputedSchemaForFilesystem() schema.SingleNestedAttribute {
 					},
 					"account_key": schema.StringAttribute{
 						Computed:    true,
+						Sensitive:   true,
 						Description: computedSecretDescription,
 					},
 					"sas_url": schema.StringAttribute{
 						Computed:    true,
+						Sensitive:   true,
 						Description: computedSecretDescription,
 					},
 					"endpoint": schema.StringAttribute{
```

## Testing

✅ All existing unit tests pass
✅ No compilation errors
✅ Build successful
✅ Manual testing confirms `terraform plan` shows no changes after apply
✅ No resource tainting occurs

**Test scenario:**
1. Created resource with Azure Blob Storage configuration
2. Ran `terraform apply` - completed successfully
3. Ran `terraform plan` - showed "No changes" (previously would show recreation needed)
4. Ran `terraform apply` again - no errors (previously would fail with inconsistent attribute error)

## Notes

This fix specifically addresses Azure Blob Storage sensitive fields. While similar patterns exist for other filesystem backends (S3, GCS, SFTP, FTP, HTTP, Crypt), this PR focuses on the reported issue with Azure Blob Storage. Similar fixes can be applied to other backends if needed.
