### PR TITLE
fix: require resource replacement when renaming users, admins, groups, or roles

### DIFF
--- a/sftpgo/admin_resource.go
+++ b/sftpgo/admin_resource.go
@@ -78,6 +78,9 @@ func (r *adminResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"username": schema.StringAttribute{
 				Required:    true,
 				Description: "Unique username.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"status": schema.Int64Attribute{
 				Required:    true,

--- a/sftpgo/group_resource.go
+++ b/sftpgo/group_resource.go
@@ -76,6 +76,9 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Unique name.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/sftpgo/role_resource.go
+++ b/sftpgo/role_resource.go
@@ -73,6 +73,9 @@ func (r *roleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"name": schema.StringAttribute{
 				Required:    true,
 				Description: "Unique name.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/sftpgo/user_resource.go
+++ b/sftpgo/user_resource.go
@@ -78,6 +78,9 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"username": schema.StringAttribute{
 				Required:    true,
 				Description: "Unique username.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"status": schema.Int64Attribute{
 				Required:    true,


### PR DESCRIPTION
## Summary
This PR fixes [issue #5](https://github.com/drakkan/terraform-provider-sftpgo/issues/5) by requiring resource replacement when a username (or name for other resources) is changed.

SFTPGo's API identifies resources by their unique names (usernames, group names, etc.). When these are modified in Terraform, the provider previously attempted an `Update` call using the *new* name as the identifier, which resulted in a `404 Not Found` error because the resource with the new name does not yet exist.

By adding `stringplanmodifier.RequiresReplace()` to these attributes, Terraform will now correctly destroy the old resource and create a new one when the name is changed.

## Changes
- Added `RequiresReplace()` plan modifier to `username` in `userResource` and `adminResource`.
- Added `RequiresReplace()` plan modifier to `name` in `groupResource` and `roleResource`.