### PR TITLE
fix: make user home_dir optional

### DIFF
--- a/sftpgo/user_resource.go
+++ b/sftpgo/user_resource.go
@@ -101,8 +101,12 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Description: "List of public keys in OpenSSH format.",
 			},
 			"home_dir": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
 				Description: "The user cannot upload or download files outside this directory. Must be an absolute path.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"email": schema.StringAttribute{
 				Optional: true,


### PR DESCRIPTION
## Summary
This PR fixes [issue #15](https://github.com/drakkan/terraform-provider-sftpgo/issues/15) by making the `home_dir` attribute for `sftpgo_user` optional and computed.

When using cloud storage backends (S3, GCS, Azure Blob), SFTPGo can automatically assign a home directory if one is not explicitly provided. Previously, the provider required this field, which forced users to provide a value even when it wasn't strictly necessary or when they wanted SFTPGo to manage it.

By making it `Optional` and `Computed` with `stringplanmodifier.UseStateForUnknown()`, Terraform will now allow users to omit the field and will correctly capture the value assigned by SFTPGo.

## Changes
- Updated `home_dir` in `userResource` schema to be `Optional` and `Computed`.
- Added `stringplanmodifier.UseStateForUnknown()` to `home_dir` to preserve the value after it's assigned by the API.