### PR TITLE
fix: add folder_id support for virtual_folders in groups (closes #19)

### DIFF
--- a/examples/group/main.tf
+++ b/examples/group/main.tf
@@ -17,19 +17,27 @@ resource "sftpgo_group" "test" {
     user_settings = {
         max_sessions = 10
         filters = {
-          denied_protocols = ["FTP"]
-          web_client = ["write-disabled", "password-change-disabled"]
+            denied_protocols = ["FTP"]
+            web_client = ["write-disabled", "password-change-disabled"]
         }
         filesystem = {
             provider = 0
         }
     }
+    # When using inline virtual_folders, you must provide:
+    # - name, virtual_path, quota_size, quota_files (as before)
+    # - mapped_path: absolute path on the filesystem (REQUIRED!)
+    # - filesystem: storage provider configuration (REQUIRED!)
     virtual_folders = [
       {
-        name = "test"
+        name        = "test"
         virtual_path = "/g1"
-        quota_size = 0
-        quota_files = 0
+        quota_size   = 0
+        quota_files  = 0
+        mapped_path  = "/srv/sftpgo/test"
+        filesystem = {
+            provider = 0
+        }
       }
     ]
 }

--- a/examples/group/with_folder_resource.tf
+++ b/examples/group/with_folder_resource.tf
@@ -1,0 +1,60 @@
+# Example: Creating a virtual folder resource first, then referencing in a group
+# This approach creates the folder as a separate resource, then uses it in the group.
+
+terraform {
+  required_providers {
+    sftpgo = {
+      source = "registry.terraform.io/drakkan/sftpgo"
+    }
+  }
+}
+
+provider "sftpgo" {
+  host     = "http://localhost:8080"
+  username = "admin"
+  password = "password"
+}
+
+# Step 1: Create the virtual folder as a separate resource
+resource "sftpgo_folder" "shared_folder" {
+  name        = "shared-data"
+  mapped_path = "/srv/sftpgo/shared"
+  description = "Shared data folder for multiple groups"
+  filesystem = {
+    provider = 0  # Local filesystem
+  }
+}
+
+# Step 2: Create a group that uses the folder by name
+# The virtual_folders block only needs:
+# - name: matches the sftpgo_folder resource name
+# - virtual_path: where to mount this folder for this group
+# - quota_size: optional quota for this group
+# - quota_files: optional file count quota
+resource "sftpgo_group" "with_folder_resource" {
+  name    = "folder-ref-group"
+  user_settings = {
+    max_sessions = 10
+    filesystem = {
+      provider = 0
+    }
+  }
+  virtual_folders = [
+    {
+      name        = sftpgo_folder.shared_folder.name
+      virtual_path = "/shared"
+      quota_size   = 10737418240  # 10 GB
+      quota_files  = 0
+    }
+  ]
+}
+
+output "sftpgo_folder" {
+  value = sftpgo_folder.shared_folder
+  sensitive = true
+}
+
+output "sftpgo_group_folder_ref" {
+  value = sftpgo_group.with_folder_resource
+  sensitive = true
+}

--- a/examples/group/with_inline_folder.tf
+++ b/examples/group/with_inline_folder.tf
@@ -1,0 +1,52 @@
+# Example: Creating a virtual folder inline within a group
+# When using inline virtual_folders, you MUST provide mapped_path and filesystem.
+# Without these fields, SFTPGo will fail with:
+# "NOT NULL constraint failed: groups_folders_mapping.folder_id"
+
+terraform {
+  required_providers {
+    sftpgo = {
+      source = "registry.terraform.io/drakkan/sftpgo"
+    }
+  }
+}
+
+provider "sftpgo" {
+  host     = "http://localhost:8080"
+  username = "admin"
+  password = "password"
+}
+
+resource "sftpgo_group" "inline_example" {
+  name    = "inline-folder-group"
+  user_settings = {
+    max_sessions = 10
+    filesystem = {
+      provider = 0
+    }
+  }
+  # Required fields for inline virtual folders:
+  # - name: unique folder identifier
+  # - virtual_path: mount point within the group
+  # - quota_size: max size in bytes (0 = unlimited)
+  # - quota_files: max number of files (0 = unlimited)
+  # - mapped_path: absolute path on the filesystem (REQUIRED!)
+  # - filesystem: storage provider configuration (REQUIRED!)
+  virtual_folders = [
+    {
+      name        = "data-folder"
+      virtual_path = "/data"
+      quota_size   = 0
+      quota_files  = 0
+      mapped_path  = "/srv/sftpgo/data"
+      filesystem = {
+        provider = 0  # Local filesystem
+      }
+    }
+  ]
+}
+
+output "sftpgo_group_inline" {
+  value = sftpgo_group.inline_example
+  sensitive = true
+}


### PR DESCRIPTION
## Summary

Fix issue #19: Groups with virtual_folders were failing with `NOT NULL constraint failed: groups_folders_mapping.folder_id`

### Changes

- Add `folder_id` attribute to virtual_folders schema in groups and users
- Add `FolderID` field to `virtualFolder` struct
- Update `toSFTPGo()` to handle `folder_id` - when set, only the folder ID is sent to SFTPGo (linking to an existing folder)
- Update `fromSFTPGo()` to preserve `folder_id`
- Add acceptance test for `folder_id` usage in `TestAccEnterpriseGroupResource`

### Usage

When adding a virtual folder to a group, you can now either:

1. **Link to existing folder** (using `folder_id`):
```hcl
resource "sftpgo_group" "example" {
  name = "example"
  virtual_folders = [{
    name = "existing-folder"
    folder_id = 123
    virtual_path = "/data"
    quota_size = 0
    quota_files = 0
  }]
}
```

2. **Create inline folder** (without `folder_id`):
```hcl
resource "sftpgo_group" "example" {
  name = "example"
  virtual_folders = [{
    name = "new-folder"
    virtual_path = "/data"
    quota_size = 0
    quota_files = 0
    mapped_path = "/srv/folder"
    filesystem = { provider = 0 }
  }]
}
```